### PR TITLE
Bug fix in _WIN32 part, and optimization

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -6,9 +6,9 @@ Game::Game(const std::string& manifest){
 	appid = std::stoi(split.at(2).substr(11, split.at(2).length() - 12));
 	name = split.at(4).substr(10, split.at(4).length() - 11);
 }
-int Game::getAppId(){
+int Game::getAppId() const{
 	return appid;
 }
-std::string Game::getName(){
+const std::string& Game::getName() const{
 	return name;
 }

--- a/Game.hpp
+++ b/Game.hpp
@@ -4,7 +4,7 @@ class Game{
         int appid;
         std::string name;
     public:
-        std::string getName();
-        int getAppId();
+        const std::string& getName() const;
+        int getAppId() const;
 		Game(const std::string&);
 };

--- a/utils/fs.cpp
+++ b/utils/fs.cpp
@@ -2,7 +2,7 @@
 namespace cutil::fs{
 	std::string getHomeDir(){
 		#ifdef _WIN32
-			return std::getenv("HOMEDRIVE") + std::getenv("HOMEDIR");	
+			return std::string(std::getenv("HOMEDRIVE")) + std::getenv("HOMEDIR");	
 		#else
 			return std::getenv("HOME");
 		#endif

--- a/utils/str.cpp
+++ b/utils/str.cpp
@@ -7,7 +7,7 @@ namespace cutil::str{
 		int delim_pos = input.find(delimiter);
 		int pos = 0;
 		while(delim_pos != std::string::npos){
-			vec.push_back(input.substr(pos, delim_pos - pos));
+			vec.emplace_back(input.substr(pos, delim_pos - pos));
 			pos = delim_pos + delim_len;	
 			delim_pos = input.find(delimiter, pos);
 		}


### PR DESCRIPTION
no structural changes

mark method const if it doesn't change the object
return const ref for classes instead of value

std::getenv return char*, so make it std::string for operator+ to work

emplace_back is more optimized for rvalue
and no performance difference compared to push_back when used with lvalue